### PR TITLE
STAR-25093: Fix sandbox API URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The `config.json` file will look like this
 
   "SANDBOX_CONFIG_COMMENT": "Do not keep the store file in the app root dir or it will restart everytime it is written to!",
   "sandboxLocalTokenStore": "../starling-api-web-starter-kit-sandbox-token-store.json",
-  "sandboxApi": "https://api-sandbox.starlingbank.com/",
+  "sandboxApi": "https://api-sandbox.starlingbank.com",
   "sandboxAccessToken": "<sandbox access token from Starling Developers site>",
   "refreshToken": "<refresh token from Starling Developers site>",
 
@@ -96,7 +96,7 @@ For the sandbox environment setup, use the config file, `config.json`, correctly
 
   "SANDBOX_CONFIG_COMMENT": "Do not keep the store file in the app root dir or it will restart everytime it is written to!",
   "sandboxLocalTokenStore": "../starling-api-web-starter-kit-sandbox-token-store.json",
-  "sandboxApi": "https://api-sandbox.starlingbank.com/",
+  "sandboxApi": "https://api-sandbox.starlingbank.com",
 
   "sandboxAccessToken": "<sandbox access token from Starling Developers site>",
   "refreshToken": "<refresh token from Starling Developers site>"

--- a/server/config.json
+++ b/server/config.json
@@ -10,7 +10,7 @@
 
   "SANDBOX_CONFIG_COMMENT": "Do not keep the token store file in the app root dir or it will restart when you are watching it with yarn run dev everytime it is written to!",
   "sandboxLocalTokenStore": "../starling-api-web-starter-kit-sandbox-token-store.json",
-  "sandboxApi": "https://api-sandbox.starlingbank.com/",
+  "sandboxApi": "https://api-sandbox.starlingbank.com",
   "sandboxAccessToken": "<sandbox access token from Starling Developers site>",
   "refreshToken": "<refresh token from Starling Developers site>",
 


### PR DESCRIPTION
Fix sandbox API URLs by removing an extra slash (which in turn results in it calling endpoints like `https://api-sandbox.starlingbank.com//api/v2/accounts` and getting 404s)