### PR TITLE
⬆️ Upgrade starling-developer-sdk@1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6945,6 +6945,24 @@
       "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
       "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I="
     },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -15832,9 +15850,9 @@
       "dev": true
     },
     "starling-developer-sdk": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/starling-developer-sdk/-/starling-developer-sdk-1.0.0.tgz",
-      "integrity": "sha512-QU1ONLnTLFsVltpRshdilXPfY7GODI90t9fP3MxmIFizJe+f0fyIjh7ph9YPlHo8asoF20gD7hP8jISk/io+/A==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/starling-developer-sdk/-/starling-developer-sdk-1.0.2.tgz",
+      "integrity": "sha512-pT7zL8z2ba7Ut1SV69nKwxGdD0fp08wgoRataC/YSS0Ql456BjGaqJ882Ik2HAEUGuwVLWD0lpQzKk4npRwjSQ==",
       "requires": {
         "axios": "^0.19.0",
         "debug": "^3.2.6",
@@ -15845,12 +15863,11 @@
       },
       "dependencies": {
         "axios": {
-          "version": "0.19.0",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
-          "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+          "version": "0.19.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+          "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
           "requires": {
-            "follow-redirects": "1.5.10",
-            "is-buffer": "^2.0.2"
+            "follow-redirects": "1.5.10"
           }
         },
         "debug": {
@@ -15859,42 +15876,17 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
             "ms": "^2.1.1"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-            }
           }
-        },
-        "follow-redirects": {
-          "version": "1.5.10",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-          "requires": {
-            "debug": "=3.1.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-              "requires": {
-                "ms": "2.0.0"
-              }
-            }
-          }
-        },
-        "is-buffer": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
         },
         "js-base64": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
-          "integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw=="
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
+          "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ=="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -16184,9 +16176,9 @@
       }
     },
     "superstruct": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.8.2.tgz",
-      "integrity": "sha512-UW9XORtsYoe/iTj/pkOjG/rKozFkFDUbgj6iPiItvfIn9IaqVnp+v1iKKenC4AY280u6IIMXAtw2DAwHwTfY4g==",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.8.4.tgz",
+      "integrity": "sha512-48Ors8IVWZm/tMr8r0Si6+mJiB7mkD7jqvIzktjJ4+EnP5tBp0qOpiM1J8sCUorKx+TXWrfb3i1UcjdD1YK/wA==",
       "requires": {
         "kind-of": "^6.0.2",
         "tiny-invariant": "^1.0.6"
@@ -16552,9 +16544,9 @@
       }
     },
     "tiny-invariant": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.6.tgz",
-      "integrity": "sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
+      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "rimraf": "^2.5.4",
     "sass-loader": "^6.0.5",
     "semantic-ui-react": "^0.75.1",
-    "starling-developer-sdk": "^1.0.0",
+    "starling-developer-sdk": "^1.0.2",
     "style-loader": "^0.13.2",
     "uid-safe": "^2.1.4",
     "url-loader": "^0.5.9",


### PR DESCRIPTION
Hi Starling,

I recently applied to Starling as a backend engineer and I wanted to run `starling-api-web-starter-kit` 
to have a better understanding of the product.

Following the instructions in the `README.md` the application kept on crashing

```
[nodemon] app crashed - waiting for file changes before starting...
```
```
require() of ~/workspace/starling-api-web-starter-kit/node_modules/superstruct/lib/index.js from ~/workspace/starling-api-web-starter-kit/node_modules/starling-developer-sdk/dist/starling.js is an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which defines all .js files in that package scope as ES modules.
Instead rename index.js to end in .cjs, change the requiring code to use import(), or remove "type": "module" from ~/workspace/starling-api-web-starter-kit/node_modules/superstruct/package.json.
```

By the look of things, `starling-developer-sdk@1.0.0` was pushed as an ES Module which appears incompatible with this project. Bumping the version to `1.0.2` (latest available on npm) have solved the issue and the projects now starts seamlessly