### PR TITLE
Use non-forked GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
 
     steps:
     - name: Checkout ${{ github.sha }}
-      uses: starlingbank/checkout@v1
+      uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: starlingbank/setup-node@v1
+      uses: actions/setup-node@c46424eee26de4078d34105d3de3cc4992202b1e
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install dependencies


### PR DESCRIPTION
These actions have been allowlisted so we can use them without forking. Would be nice to use the official ones and clean up our GitHub org a bit.